### PR TITLE
prevent a race condition in locking Select.choices

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::hash_map::{HashMap, Entry};
+use std::collections::btree_map::{BTreeMap, Entry};
 use std::rc::Rc;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 
@@ -26,7 +26,7 @@ pub struct Select<'c> {
     /// A mutex for guarding notification from channels.
     cond_mutex: Arc<Mutex<()>>,
     /// The set of all arms.
-    choices: HashMap<ChannelId, Box<Choice + 'c>>,
+    choices: BTreeMap<ChannelId, Box<Choice + 'c>>,
     /// Scratch space for quickly shuffling the order in which we try to
     /// synchronize an operation in select.
     ids: Option<Vec<ChannelId>>,
@@ -98,7 +98,7 @@ impl<'c> Select<'c> {
         Select {
             cond: Arc::new(Condvar::new()),
             cond_mutex: Arc::new(Mutex::new(())),
-            choices: HashMap::new(),
+            choices: BTreeMap::new(),
             ids: None,
         }
     }
@@ -124,7 +124,7 @@ impl<'c> Select<'c> {
     fn maybe_try_select(&mut self, try: bool) -> Option<ChannelId> {
         fn try_sync<'c>(
             ids: &mut Option<Vec<ChannelId>>,
-            choices: &mut HashMap<ChannelId, Box<Choice + 'c>>,
+            choices: &mut BTreeMap<ChannelId, Box<Choice + 'c>>,
         ) -> Option<ChannelId> {
             let mut ids = ids.as_mut().unwrap();
             rand::thread_rng().shuffle(ids);


### PR DESCRIPTION
I think this commit fixes issue #5.

When multiple threads were selecting on the same channels,
the following race condition could occur in Select::maybe_try_select:

Provided
- Two treads: `A` and `B` and two channels `chan1` and `chan2`
- self.choices for thread `A` is [`chan1`, `chan2`]
- self.choices for thread `B` is [`chan2`, `chan1`]

In a for loop in `Select::maybe_try_select`, the following happens:
`A` tries to lock `chan1`, this succeeds
`B` tries to lock `chan2`, this succeeds
`A` tries to lock `chan2`, this blocks, because `B` has locked it
`B` tries to lock `chan1`, this blocks, because `A` has locked it
_deadlock!_

This can be prevented by making sure that the different threads all
lock the channels in the same order. The order of HashMap::iter()
is arbitrary, so the bug should be fixed when we instead use a BTreeMap.
