### PR TITLE
select: do not shuffle channel ids in `Select::maybe_try_select`

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -126,9 +126,14 @@ impl<'c> Select<'c> {
             ids: &mut Option<Vec<ChannelId>>,
             choices: &mut BTreeMap<ChannelId, Box<Choice + 'c>>,
         ) -> Option<ChannelId> {
-            let mut ids = ids.as_mut().unwrap();
-            rand::thread_rng().shuffle(ids);
-            for key in ids {
+            let ids = ids.as_mut().unwrap();
+            let iter = if ids.len() > 1 {
+                let rotate = rand::thread_rng().gen::<usize>() % ids.len();
+                ids.iter().cycle().skip(rotate).take(ids.len())
+            } else {
+                ids.iter().cycle().skip(0).take(ids.len())
+            };
+            for key in iter {
                 if choices.get_mut(key).unwrap().try() {
                     return Some(*key);
                 }


### PR DESCRIPTION
I was browsing through the source code and I did not understand why, in the `Select::maybe_try_select` function, the order of the channel ids, in which they are `try`'d should be random. This patch removes this randomization, so you can see what (pieces of code) I mean.
