### PR TITLE
Added poisoning the wait group on panic.

### DIFF
--- a/src/wait_group.rs
+++ b/src/wait_group.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 use std::sync::{Arc, Condvar, Mutex};
+use std::thread::panicking;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// `WaitGroup` provides synchronization on the completion of threads.
 ///
@@ -34,6 +36,22 @@ pub struct WaitGroup(Arc<WaitGroupInner>);
 struct WaitGroupInner {
     cond: Condvar,
     count: Mutex<i32>,
+    poisoned: AtomicBool,
+}
+
+impl Drop for WaitGroup {
+    fn drop(&mut self) {
+        let mut count = self.0.count.lock().unwrap();
+        // We require count to be over zero to not trigger another panic when the WaitGroup
+        // of the waiting thread gets dropped on panic.
+        // Caveat: We can't be sure if we are panicking after done is being called
+        if *count > 0 && panicking() {
+            *count -= 1;
+            assert!(*count >= 0);
+            self.0.poisoned.store(true, Ordering::Release);
+            self.0.cond.notify_all();
+        }
+    }
 }
 
 impl WaitGroup {
@@ -42,6 +60,7 @@ impl WaitGroup {
         WaitGroup(Arc::new(WaitGroupInner {
             cond: Condvar::new(),
             count: Mutex::new(0),
+            poisoned: AtomicBool::new(false),
         }))
     }
 
@@ -69,9 +88,27 @@ impl WaitGroup {
     ///
     /// This unblocks when the internal count is `0`.
     pub fn wait(&self) {
-        let mut count = self.0.count.lock().unwrap();
-        while *count > 0 {
-            count = self.0.cond.wait(count).unwrap();
+        let result = self.try_wait();
+
+        if let Err(()) = result {
+            panic!("Another thread this thread was waiting for panicked and dropped the WaitGroup.");
+        }
+    }
+
+    /// Wait until all threads have completed. Returns a Result to tell whether a thread panicked.
+    ///
+    /// This unblocks when the internal count is `0`.
+    pub fn try_wait(&self) -> Result<(), ()> {
+        {
+            let mut count = self.0.count.lock().unwrap();
+            while *count > 0 {
+                count = self.0.cond.wait(count).unwrap();
+            }
+        }
+        if self.0.poisoned.load(Ordering::Acquire) {
+            Err(())
+        } else {
+            Ok(())
         }
     }
 }
@@ -80,5 +117,93 @@ impl fmt::Debug for WaitGroup {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let count = self.0.count.lock().unwrap();
         write!(f, "WaitGroup {{ count: {:?} }}", *count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread::{spawn, sleep};
+    use std::time::{Instant, Duration};
+    use super::WaitGroup;
+
+    #[test]
+    fn test_wait() {
+
+        let wg1 = WaitGroup::new();
+        let wg2 = wg1.clone();
+        wg2.add(1);
+
+        let start_time = Instant::now();
+
+        spawn(move || {
+            sleep(Duration::from_secs(1));
+            wg2.done();
+        });
+
+        wg1.wait();
+
+        assert!(Instant::now().duration_since(start_time) > Duration::from_secs(1));
+
+        // This does have some shaky indeterminism,
+        // but in *practice* it should never fail.
+        assert!(Instant::now().duration_since(start_time) < Duration::from_secs(2));
+
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_panicking() {
+
+        let wg1 = WaitGroup::new();
+        let wg2 = wg1.clone();
+        wg2.add(1);
+
+        let start_time = Instant::now();
+
+        spawn(move || {
+            sleep(Duration::from_secs(1));
+            panic!("Thread panicked and done won't be called!");
+            wg2.done();
+        });
+
+        wg1.wait();
+    }
+
+    #[test]
+    fn test_try_wait() {
+
+        let wg1 = WaitGroup::new();
+        let wg2 = wg1.clone();
+        wg2.add(1);
+        let wg3 = wg1.clone();
+        wg3.add(1);
+
+        let start_time = Instant::now();
+
+        spawn(move || {
+            sleep(Duration::from_secs(1));
+            panic!("Sleeping thread panicked and done won't be called!");
+            wg2.done();
+        });
+
+        spawn(move || {
+            panic!("Non-sleeping thread panicked and done won't be called!");
+            wg3.done();
+        });
+
+        let panicked = wg1.try_wait();
+
+        // Even though the non-sleeping thread panicked right away, try_wait should still
+        // wait for all threads to finish (via done() or panic) and only then return the error.
+
+        assert!(Instant::now().duration_since(start_time) > Duration::from_secs(1));
+
+        // This does have some shaky indeterminism,
+        // but in *practice* it should never fail.
+        assert!(Instant::now().duration_since(start_time) < Duration::from_secs(2));
+
+
+        assert_eq!(panicked, Err(()));
+
     }
 }


### PR DESCRIPTION
Added poisoning the `WaitGroups ` on panic, plus a `try_wait` method to recover from waiting a panicked thread. Added tests for WaitGroups.

At the moment, if a thread being waited for panics, a deadlock will occur. I added a `Drop` implementation that decrements the counter on panic, but also marks the `WaitGroup` as poisoned.

I think that a whole program panic is better than a deadlock. At least in my use case, deadlocks are highly undesirable since they can go undetected (and cause timeouts somewhere else later), whereas whole program panic signals clearly that there is a bug.

There would have been another implementation strategy: setting the `count` to -1 on panic, and checking that in the `wait` function. That has the upside of not needing a separate `poisoned` flag, but it has also the downside that the count of pending threads gets lost. This has the semantic difference between `wait` panicking immediately on panic, vs. it panicking later when all the threads have finished, either normally or via panicking. I guess that panicking right away would be acceptable with `wait` panicking, since one can't expect the program state to be in a full coherent state after a panic, but adding `try_wait` for controlled error handling made me to think that it might be preferable if the wait functions waited for all threads to finish.

If you prefer not adding a flag and just setting `count` to -1, I can do that. (Of course there's the third alternative where the count still counts, but negating it means that there has been a panic. However, that comes with a cost of special-casing the code.)