### PR TITLE
Fix chan_select!

### DIFF
--- a/examples/default.rs
+++ b/examples/default.rs
@@ -9,11 +9,11 @@ fn main() {
     let boom = chan::after_ms(500);
     loop {
         chan_select! {
+            tick.recv() => println!("tick."),
             default => {
                 println!("   .");
                 thread::sleep(Duration::from_millis(50));
             },
-            tick.recv() => println!("tick."),
             boom.recv() => { println!("BOOM!"); return; },
         }
     }

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -9,11 +9,11 @@ fn main() {
     let boom = chan::after_ms(500);
     loop {
         chan_select! {
-            tick.recv() => println!("tick."),
             default => {
                 println!("   .");
                 thread::sleep(Duration::from_millis(50));
             },
+            tick.recv() => println!("tick."),
             boom.recv() => { println!("BOOM!"); return; },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1475,11 +1475,19 @@ macro_rules! chan_select {
             default => $default,
             $($chan.$meth($($send)*) $(-> $name)* => $code),+);
     };
+    ($select:ident, $(
+        $chan:ident.$meth:ident($($send:expr)*)
+        $(-> $name:pat)* => $code:expr,
+    )+) => {
+        chan_select!(
+            $select,
+            $($chan.$meth($($send)*) $(-> $name)* => $code),+);
+    };
     ($select:ident, default => $default:expr, $(
         $chan:ident.$meth:ident($($send:expr)*)
         $(-> $name:pat)* => $code:expr
     ),+) => {{
-        let mut sel = &mut $select;
+        let sel = &mut $select;
         $(let $chan = sel.$meth(&$chan $(, $send)*);)+
         let which = sel.try_select();
         $(if which == Some($chan.id()) {
@@ -1490,17 +1498,9 @@ macro_rules! chan_select {
     }};
     ($select:ident, $(
         $chan:ident.$meth:ident($($send:expr)*)
-        $(-> $name:pat)* => $code:expr,
-    )+) => {
-        chan_select!(
-            $select,
-            $($chan.$meth($($send)*) $(-> $name)* => $code),+);
-    };
-    ($select:ident, $(
-        $chan:ident.$meth:ident($($send:expr)*)
         $(-> $name:pat)* => $code:expr
     ),+) => {{
-        let mut sel = &mut $select;
+        let sel = &mut $select;
         $(let $chan = sel.$meth(&$chan $(, $send)*);)+
         let which = sel.select();
         $(if which == $chan.id() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1568,17 +1568,17 @@ macro_rules! chan_select {
     };
 
     ($select:ident, default => $default:expr, $($tt:tt)*) => {
-        compile_error!("Error: There is a comma missing after one of the select cases");
+        compile_error!("Error: There is a comma missing after one of the select cases.");
     };
     (default => $default:expr, $($tt:tt)*) => {
-        compile_error!("Error: There is a comma missing after one of the select cases");
+        compile_error!("Error: There is a comma missing after one of the select cases.");
     };
 
     ($select:ident, default => $($tt:tt)*) => {
-        compile_error!("Error: There is a comma missing after the default case");
+        compile_error!("Error: There is a comma missing after the default case.");
     };
     (default => $($tt:tt)*) => {
-        compile_error!("Error: There is a comma missing after the default case");
+        compile_error!("Error: There is a comma missing after the default case.");
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1545,40 +1545,40 @@ macro_rules! chan_select {
         $chan:ident$(($($dontcare:expr)*))*.$meth:ident($($send:expr)*)
         $(-> $name:pat)* => $code:expr
     ),+$(,)*) => {
-        compile_error!("Error: The channel name in each case must be a simple identifier, not a function call.  At least one of the cases violates this rule.");
+        compile_error!("The channel name in each case must be a simple identifier, not a function call.  At least one of the cases violates this rule.");
     };
     (default => $default:expr, $(
         $chan:ident$(($($dontcare:expr)*))*.$meth:ident($($send:expr)*)
         $(-> $name:pat)* => $code:expr
     ),+$(,)*) => {
-        compile_error!("Error: The channel name in each case must be a simple identifier, not a function call.  At least one of the cases violates this rule.");
+        compile_error!("The channel name in each case must be a simple identifier, not a function call.  At least one of the cases violates this rule.");
     };
 
     ($select:ident, default => $default:expr, $(
         $($chan:ident$(($($dontcare:expr)*))*).+
         $(-> $name:pat)* => $code:expr
     ),+$(,)*) => {
-        compile_error!("Error: The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
+        compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
     };
     (default => $default:expr, $(
         $($chan:ident$(($($dontcare:expr)*))*).+
         $(-> $name:pat)* => $code:expr
     ),+$(,)*) => {
-        compile_error!("Error: The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
+        compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
     };
 
     ($select:ident, default => $default:expr, $($tt:tt)*) => {
-        compile_error!("Error: There is a comma missing after one of the select cases.");
+        compile_error!("There is a comma missing after one of the select cases.");
     };
     (default => $default:expr, $($tt:tt)*) => {
-        compile_error!("Error: There is a comma missing after one of the select cases.");
+        compile_error!("There is a comma missing after one of the select cases.");
     };
 
     ($select:ident, default => $($tt:tt)*) => {
-        compile_error!("Error: There is a comma missing after the default case.");
+        compile_error!("There is a comma missing after the default case.");
     };
     (default => $($tt:tt)*) => {
-        compile_error!("Error: There is a comma missing after the default case.");
+        compile_error!("There is a comma missing after the default case.");
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1547,7 +1547,19 @@ macro_rules! chan_select {
     ),+$(,)*) => {
         compile_error!("The channel name in each case must be a simple identifier, not a function call.  At least one of the cases violates this rule.");
     };
+    ($select:ident, $(
+        $chan:ident$(($($dontcare:expr)*))*.$meth:ident($($send:expr)*)
+        $(-> $name:pat)* => $code:expr
+    ),+$(,)*) => {
+        compile_error!("The channel name in each case must be a simple identifier, not a function call.  At least one of the cases violates this rule.");
+    };
     (default => $default:expr, $(
+        $chan:ident$(($($dontcare:expr)*))*.$meth:ident($($send:expr)*)
+        $(-> $name:pat)* => $code:expr
+    ),+$(,)*) => {
+        compile_error!("The channel name in each case must be a simple identifier, not a function call.  At least one of the cases violates this rule.");
+    };
+    ($(
         $chan:ident$(($($dontcare:expr)*))*.$meth:ident($($send:expr)*)
         $(-> $name:pat)* => $code:expr
     ),+$(,)*) => {
@@ -1560,7 +1572,19 @@ macro_rules! chan_select {
     ),+$(,)*) => {
         compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
     };
+    ($select:ident, $(
+        $($chan:ident$(($($dontcare:expr)*))*).+
+        $(-> $name:pat)* => $code:expr
+    ),+$(,)*) => {
+        compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
+    };
     (default => $default:expr, $(
+        $($chan:ident$(($($dontcare:expr)*))*).+
+        $(-> $name:pat)* => $code:expr
+    ),+$(,)*) => {
+        compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
+    };
+    ($(
         $($chan:ident$(($($dontcare:expr)*))*).+
         $(-> $name:pat)* => $code:expr
     ),+$(,)*) => {
@@ -1568,17 +1592,25 @@ macro_rules! chan_select {
     };
 
     ($select:ident, default => $default:expr, $($tt:tt)*) => {
-        compile_error!("There is a comma missing after one of the select cases.");
+        compile_error!("There is likely a comma missing after one of the select cases.");
     };
     (default => $default:expr, $($tt:tt)*) => {
-        compile_error!("There is a comma missing after one of the select cases.");
+        compile_error!("There is likely a comma missing after one of the select cases.");
     };
 
     ($select:ident, default => $($tt:tt)*) => {
-        compile_error!("There is a comma missing after the default case.");
+        compile_error!("There is likely a comma missing after the default case.");
     };
     (default => $($tt:tt)*) => {
-        compile_error!("There is a comma missing after the default case.");
+        compile_error!("There is likely a comma missing after the default case.");
+    };
+
+    ($select:ident, $($tt:tt)*) => {
+        compile_error!("There is likely a comma missing after one of the select cases.");
+    };
+
+    ($($tt:tt)*) => {
+        compile_error!("There is likely a comma missing after one of the select cases.");
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1572,23 +1572,24 @@ macro_rules! chan_select {
     ),+$(,)*) => {
         compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
     };
-    ($select:ident, $(
-        $($chan:ident$(($($dontcare:expr)*))*).+
-        $(-> $name:pat)* => $code:expr
-    ),+$(,)*) => {
-        compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
-    };
     (default => $default:expr, $(
         $($chan:ident$(($($dontcare:expr)*))*).+
         $(-> $name:pat)* => $code:expr
     ),+$(,)*) => {
         compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
     };
+
+    ($select:ident, $(
+        $($chan:ident$(($($dontcare:expr)*))*).+
+        $(-> $name:pat)* => $code:expr
+    ),+$(,)*) => {
+        compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). Also, the 'default' case must be the first case. At least one of the cases violates one of these rules.");
+    };
     ($(
         $($chan:ident$(($($dontcare:expr)*))*).+
         $(-> $name:pat)* => $code:expr
     ),+$(,)*) => {
-        compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). At least one of the cases violates this rule.");
+        compile_error!("The channel name in each case must be a simple identifier, not a function call, and you cannot access any members of that identifier other than the method (e.g. recv()). Also, the 'default' case must be the first case. At least one of the cases violates one of these rules.");
     };
 
     ($select:ident, default => $default:expr, $($tt:tt)*) => {


### PR DESCRIPTION
I've seen `chan_select!` used as a counterexample to several things over the years, and today's use of it finally moved me from apathy to actually seeing about a fix for this perennial issue.

This PR adds diagnostic error messages to all of the cases listed as failure modes, and it prevents infinite recursion in all 3. For example, if there is a missing comma after a case, the error message indicates as much:

```
error: There is likely a comma missing after one of the select cases.
  --> examples/default.rs:11:9
   |
11 | /         chan_select! {
12 | |             default => {
13 | |                 println!("   .");
14 | |                 thread::sleep(Duration::from_millis(50));
...  |
17 | |             boom.recv() => { println!("BOOM!"); return; },
18 | |         }
   | |_________^
   |
   = note: this error originates in a macro outside of the current crate

error: aborting due to previous error
```

If the comma missing is the one immediately following the `default` case, then the error is specialized to report exactly that comma as being missing. The other error cases have their own error messages.

`cargo test` passes with flying colors. It is probably worth testing this new macro against some other real-world uses of `chan_select!` to ensure that nothing is broken by this alteration of the macro.